### PR TITLE
Add missing parameter for private publish

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,7 +14,7 @@ on:
     branches:
       - main
       - dev
-
+      - fix-push-workflow
 jobs:
   build:
     uses: ./.github/workflows/_build.yml 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,7 +14,7 @@ on:
     branches:
       - main
       - dev
-      - fix-push-workflow
+
 jobs:
   build:
     uses: ./.github/workflows/_build.yml 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -24,3 +24,4 @@ jobs:
     needs: [build]
     secrets: inherit
     with:
+      remote-docker-image: "us-central1-docker.pkg.dev/topl-shared-project-dev/topl-artifacts-dev/faucet"


### PR DESCRIPTION
The `remote-docker-image` parameter for the workflow was missing. Add that in this PR.

Confirm by running workflow: https://github.com/Topl/faucet/actions/runs/5802036406/job/15727644084